### PR TITLE
Add raft message handling

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,9 @@
+use crate::membership::MembershipChange;
+use raft::eraftpb::Message as RaftMessage;
+
+#[derive(Debug)]
+pub enum Event {
+    Raft(RaftMessage),
+    Membership(MembershipChange),
+}
+

--- a/src/membership.rs
+++ b/src/membership.rs
@@ -1,5 +1,5 @@
 #[derive(Debug)]
 pub enum MembershipChange {
-    AddNode(u64),
+    AddNode { id: u64, address: String },
     RemoveNode(u64),
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,6 @@
-use tonic::{Request, Response, Status};
 use prost::Message;
-use raft::{eraftpb::Message as RaftProtoMessage};
+use raft::eraftpb::Message as RaftProtoMessage;
+use tonic::{Request, Response, Status};
 
 pub mod raftio {
     tonic::include_proto!("raftio");
@@ -8,18 +8,19 @@ pub mod raftio {
 
 use raftio::raft_transport_server::RaftTransport;
 pub use raftio::raft_transport_server::RaftTransportServer;
-use raftio::{RaftMessage, JoinRequest, JoinResponse, LeaveRequest, LeaveResponse};
+use raftio::{JoinRequest, JoinResponse, LeaveRequest, LeaveResponse, RaftMessage};
 
-use tokio::sync::mpsc::Sender;
+use crate::events::Event;
 use crate::membership::MembershipChange;
+use tokio::sync::mpsc::Sender;
 
 pub struct RaftService {
-    pub tx: Sender<MembershipChange>,
+    pub tx: Sender<Event>,
     // pub node: Arc<Mutex<RawNode<MemStorage>>>,
 }
 
 impl RaftService {
-    pub fn new(tx: Sender<MembershipChange>) -> Self {
+    pub fn new(tx: Sender<Event>) -> Self {
         Self { tx }
     }
 }
@@ -33,22 +34,29 @@ impl RaftTransport for RaftService {
         let msg = request.into_inner();
         println!("Received RaftMessage: {} bytes", msg.data.len());
 
-        // This will work if ProstMessage trait is in scope and raft 0.7+ is used!
         match RaftProtoMessage::decode(&*msg.data) {
-            Ok(parsed) => println!("Parsed Raft message: {:?}", parsed.get_msg_type()),
+            Ok(parsed) => {
+                if let Err(e) = self.tx.send(Event::Raft(parsed)).await {
+                    eprintln!("Failed to forward raft message: {e}");
+                }
+            }
             Err(e) => println!("Failed to decode raft message: {e}"),
         }
 
         Ok(Response::new(RaftMessage { data: vec![] }))
     }
 
-    async fn join(
-        &self,
-        request: Request<JoinRequest>,
-    ) -> Result<Response<JoinResponse>, Status> {
+    async fn join(&self, request: Request<JoinRequest>) -> Result<Response<JoinResponse>, Status> {
         let jr = request.into_inner();
         println!("Join request for node {}", jr.id);
-        if let Err(e) = self.tx.send(MembershipChange::AddNode(jr.id)).await {
+        if let Err(e) = self
+            .tx
+            .send(Event::Membership(MembershipChange::AddNode {
+                id: jr.id,
+                address: jr.address,
+            }))
+            .await
+        {
             eprintln!("Failed to forward join request: {e}");
         }
         Ok(Response::new(JoinResponse {}))
@@ -60,7 +68,11 @@ impl RaftTransport for RaftService {
     ) -> Result<Response<LeaveResponse>, Status> {
         let lr = request.into_inner();
         println!("Leave request for node {}", lr.id);
-        if let Err(e) = self.tx.send(MembershipChange::RemoveNode(lr.id)).await {
+        if let Err(e) = self
+            .tx
+            .send(Event::Membership(MembershipChange::RemoveNode(lr.id)))
+            .await
+        {
             eprintln!("Failed to forward leave request: {e}");
         }
         Ok(Response::new(LeaveResponse {}))


### PR DESCRIPTION
## Summary
- add `Event` enum to wrap raft messages and membership changes
- support processing of `Event` in the main loop
- send decoded raft messages from `RaftService`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68769eff0e34832ca33e69d50d2aeee8