### PR TITLE
Handle join by fetching leader conf state

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -11,7 +11,9 @@ message JoinRequest {
   string address = 2;
 }
 
-message JoinResponse {}
+message JoinResponse {
+  bytes conf_state = 1;
+}
 
 message LeaveRequest {
   uint64 id = 1;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -67,12 +67,12 @@ impl RaftTransport for RaftService {
         {
             eprintln!("Failed to forward join request: {e}");
         }
-        let state = self
+        let snap = self
             .storage
-            .initial_state()
-            .map_err(|e| Status::internal(format!("failed to get conf state: {e}")))?;
+            .snapshot(0, jr.id)
+            .map_err(|e| Status::internal(format!("failed to get snapshot: {e}")))?;
         let mut data = Vec::new();
-        state.conf_state.encode(&mut data).unwrap();
+        snap.get_metadata().get_conf_state().encode(&mut data).unwrap();
         Ok(Response::new(JoinResponse { conf_state: data }))
     }
 


### PR DESCRIPTION
## Summary
- extend JoinResponse to return the current ConfState
- share MemStorage with RaftService
- when joining an existing node, request the configuration from the leader and use it to initialise storage
- start gRPC server after storage is created

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6878a3cf397c832c8067dc6ae1888599