### PR TITLE
leaving

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -27,6 +27,7 @@ pub async fn handle_event(
     match evt {
         Event::Membership(MembershipChange::AddNode { id, address }) => {
             {
+                // FIXME: this shouldn't be here since it just proposes to add new node, not official
                 let mut map = peer_addresses.write().await;
                 map.insert(id, address);
             }
@@ -43,10 +44,6 @@ pub async fn handle_event(
             }
         }
         Event::Membership(MembershipChange::RemoveNode(id)) => {
-            {
-                let mut map = peer_addresses.write().await;
-                map.remove(&id);
-            }
             let mut n = node.write().await;
             let cc = ConfChangeV2 {
                 changes: vec![ConfChangeSingle {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -68,6 +68,11 @@ impl RaftTransport for RaftService {
         let jr = request.into_inner();
         println!("Join request for node {}", jr.id);
 
+        let peer_addresses = self.peer_addresses.read().await.clone();
+        if peer_addresses.contains_key(&jr.id) {
+            return Err(Status::already_exists(format!("node id {} already exits", jr.id)));
+        }
+
         {
             let node = self.node.read().await;
             if node.raft.state != StateRole::Leader {


### PR DESCRIPTION
sending MsgAppend to the leaving node, it sends back MsgAppendResponse cause leader cant step on the message since it removes the node.

```
Leave request for node 2
Applying conf change: ConfChangeV2 { transition: Auto, changes: [ConfChangeSingle { change_type: RemoveNode, node_id: 2 }], context: [] }
remove node 1 == 2
sending message to peer 127.0.0.1:19101, MsgAppend
Aug 04 17:10:38.304 INFO[/home/mozart/.cargo/registry/src/index.crates.io-6f17d22bba15001f/raft-0.7.0/src/raft.rs:2668:9] switched to configuration, config: Configuration { voters: Configuration { incoming: Configuration { voters: {1} }, outgoing: Configuration { voters: {} } }, learners: {}, learners_next: {}, auto_leave: false }, raft_id: 1
hello? None
sending light message to peer 127.0.0.1:19101, MsgAppend
hi None
Error stepping raft message: raft: cannot step as peer not found
Error stepping raft message: raft: cannot step as peer not found
```


```
sending message to peer 127.0.0.1:19099, MsgAppendResponse
hello? None
Applying conf change: ConfChangeV2 { transition: Auto, changes: [ConfChangeSingle { change_type: RemoveNode, node_id: 2 }], context: [] }
remove node 2 == 2
exiting...
sending message to peer 127.0.0.1:19099, MsgAppendResponse
Aug 04 17:10:38.308 INFO[/home/mozart/.cargo/registry/src/index.crates.io-6f17d22bba15001f/raft-0.7.0/src/raft.rs:2668:9] switched to configuration, config: Configuration { voters: Configuration { incoming: Configuration { voters: {1} }, outgoing: Configuration { voters: {} } }, learners: {}, learners_next: {}, auto_leave: false }, raft_id: 2
hello? None
```